### PR TITLE
release(processpuzzle-core): 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <base-rule-backend.version>1.0.5-SNAPSHOT</base-rule-backend.version>
         <base-state-backend.version>1.0.5-SNAPSHOT</base-state-backend.version>
         <base-workflow-backend.version>1.0.5-SNAPSHOT</base-workflow-backend.version>
-        <processpuzzle-core.version>1.0.5-SNAPSHOT</processpuzzle-core.version>
+        <processpuzzle-core.version>1.0.5</processpuzzle-core.version>
         <processpuzzle-store.version>1.0.5-SNAPSHOT</processpuzzle-store.version>
     </properties>
 


### PR DESCRIPTION
Release **processpuzzle-core** at **1.0.5**.

The Maven Central deploy workflow triggers on push to `release/processpuzzle-core/1.0.5`. Once it succeeds and this PR is merged, run:

```
nx run processpuzzle-core:release-finalize
```

to bump develop to the next -SNAPSHOT.