### PR TITLE
release(api-contracts): 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
              property via <version>${<lib>.version}</version>. Bumped by
              tools/scripts/release-java-lib.mjs. flatten-maven-plugin resolves the reference
              at publish time so the pom deployed to Central carries a literal version. -->
-        <api-contracts.version>1.0.5-SNAPSHOT</api-contracts.version>
+        <api-contracts.version>1.0.5</api-contracts.version>
         <base-desktop-backend.version>1.0.5-SNAPSHOT</base-desktop-backend.version>
         <base-rule-backend.version>1.0.5-SNAPSHOT</base-rule-backend.version>
         <base-state-backend.version>1.0.5-SNAPSHOT</base-state-backend.version>


### PR DESCRIPTION
Release **api-contracts** at **1.0.5**.

The Maven Central deploy workflow triggers on push to `release/api-contracts/1.0.5`. Once it succeeds and this PR is merged, run:

```
nx run api-contracts:release-finalize
```

to bump develop to the next -SNAPSHOT.