### PR TITLE
release(processpuzzle-store): 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <base-state-backend.version>1.0.5-SNAPSHOT</base-state-backend.version>
         <base-workflow-backend.version>1.0.5-SNAPSHOT</base-workflow-backend.version>
         <processpuzzle-core.version>1.0.6-SNAPSHOT</processpuzzle-core.version>
-        <processpuzzle-store.version>1.0.5-SNAPSHOT</processpuzzle-store.version>
+        <processpuzzle-store.version>1.0.5</processpuzzle-store.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Release **processpuzzle-store** at **1.0.5**.

The Maven Central deploy workflow triggers on push to `release/processpuzzle-store/1.0.5`. Once it succeeds and this PR is merged, run:

```
nx run processpuzzle-store:release-finalize
```

to bump develop to the next -SNAPSHOT.