### PR TITLE
release(processpuzzle-store): 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <base-state-backend.version>1.0.4</base-state-backend.version>
         <base-workflow-backend.version>1.0.4</base-workflow-backend.version>
         <processpuzzle-core.version>1.0.5</processpuzzle-core.version>
-        <processpuzzle-store.version>1.0.4</processpuzzle-store.version>
+        <processpuzzle-store.version>1.0.5</processpuzzle-store.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Release **processpuzzle-store** at **1.0.5** (patch bump).

The Maven Central deploy workflow triggers on push to `release/processpuzzle-store/1.0.5`. On publish success the release-merge composite auto-merges this PR into develop and opens+merges a PR into master.