### PR TITLE
release(base-rule-backend): 1.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
              flag) on release; flatten-maven-plugin resolves the reference at publish time. -->
         <api-contracts.version>1.0.5</api-contracts.version>
         <base-desktop-backend.version>1.0.5</base-desktop-backend.version>
-        <base-rule-backend.version>1.0.2</base-rule-backend.version>
+        <base-rule-backend.version>1.0.3</base-rule-backend.version>
         <base-state-backend.version>1.0.4</base-state-backend.version>
         <base-workflow-backend.version>1.0.4</base-workflow-backend.version>
         <processpuzzle-core.version>1.0.5</processpuzzle-core.version>


### PR DESCRIPTION
Release **base-rule-backend** at **1.0.3** (patch bump).

The Maven Central deploy workflow triggers on push to `release/base-rule-backend/1.0.3`. On publish success the release-merge composite auto-merges this PR into develop and opens+merges a PR into master.