### PR TITLE
release(base-workflow-backend): 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <base-desktop-backend.version>1.0.5</base-desktop-backend.version>
         <base-rule-backend.version>1.0.3</base-rule-backend.version>
         <base-state-backend.version>1.0.5</base-state-backend.version>
-        <base-workflow-backend.version>1.0.4</base-workflow-backend.version>
+        <base-workflow-backend.version>1.0.5</base-workflow-backend.version>
         <processpuzzle-core.version>1.0.5</processpuzzle-core.version>
         <processpuzzle-store.version>1.0.5</processpuzzle-store.version>
     </properties>


### PR DESCRIPTION
Release **base-workflow-backend** at **1.0.5** (patch bump).

The Maven Central deploy workflow triggers on push to `release/base-workflow-backend/1.0.5`. On publish success the release-merge composite auto-merges this PR into develop and opens+merges a PR into master.