### PR TITLE
release(processpuzzle-testbed): 1.4.0

### DIFF
--- a/apps/processpuzzle-testbed/package.json
+++ b/apps/processpuzzle-testbed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processpuzzle/testbed",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Test application for @processpuzzle libraries",
   "private": false,
   "repository": {


### PR DESCRIPTION
Release **processpuzzle-testbed** at **1.4.0** (minor bump).

The npm publish workflow triggers on push to `release/processpuzzle-testbed/1.4.0`. Merge this PR after publish succeeds.