### PR TITLE
release(api-contracts): 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
              CURRENT PUBLISHED version, no SNAPSHOT between releases.
              tools/scripts/release-java-lib.mjs bumps to the next version (per the increment
              flag) on release; flatten-maven-plugin resolves the reference at publish time. -->
-        <api-contracts.version>1.0.5</api-contracts.version>
+        <api-contracts.version>1.0.6</api-contracts.version>
         <base-desktop-backend.version>1.0.5</base-desktop-backend.version>
         <base-rule-backend.version>1.0.3</base-rule-backend.version>
         <base-state-backend.version>1.0.5</base-state-backend.version>


### PR DESCRIPTION
Release **api-contracts** at **1.0.6** (patch bump).

The Maven Central deploy workflow triggers on push to `release/api-contracts/1.0.6`. On publish success the release-merge composite auto-merges this PR into develop and opens+merges a PR into master.