### PR TITLE
fix(ci): delete release branch via API in release-merge

### DIFF
--- a/.github/actions/release-merge/action.yml
+++ b/.github/actions/release-merge/action.yml
@@ -57,7 +57,16 @@ runs:
           --title "release: merge $BRANCH into master" \
           --body "Auto-created by the release workflow after successful publish. Brings master to the released state."
 
-        echo "Merging release branch into master and deleting it..."
-        gh pr merge "$BRANCH" --merge --delete-branch
+        echo "Merging release branch into master..."
+        gh pr merge "$BRANCH" --merge
+
+        # Delete the remote branch via the API rather than `gh pr merge
+        # --delete-branch`: the latter also deletes the local checked-out
+        # branch, forcing a `git checkout` of the default branch, which aborts
+        # when the runner's working tree has build-time changes (e.g. a
+        # regenerated package-lock.json). The API delete touches no local git.
+        echo "Deleting remote branch $BRANCH..."
+        gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" || \
+          echo "WARNING: could not delete remote branch $BRANCH (already gone?)."
 
         echo "Done. Branch $BRANCH merged to develop and master, then deleted."


### PR DESCRIPTION
## Problem

Release run [29399642848](https://github.com/ZsZs/processpuzzle/actions/runs/29399642848) failed on its final step even though the library published to Maven Central and both develop/master PRs merged successfully.

The `release-merge` action's last line, `gh pr merge "$BRANCH" --merge --delete-branch`, deletes the *local* checked-out release branch too, forcing a `git checkout` of the default branch on the runner. The build steps leave the working tree dirty (a regenerated `package-lock.json`), so the checkout aborts:

```
error: Your local changes to the following files would be overwritten by checkout:
	package-lock.json
```

and the step exits 1 — despite the release itself being complete.

## Fix

Drop `--delete-branch` and delete the remote branch via the GitHub API (`gh api -X DELETE .../git/refs/heads/$BRANCH`), which touches no local git and is unaffected by a dirty working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)