### PR TITLE
fix(ci): build in-repo deps from source before release deploy

### DIFF
--- a/.github/actions/release-java/action.yml
+++ b/.github/actions/release-java/action.yml
@@ -82,6 +82,18 @@ runs:
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       working-directory: ${{inputs.base_dir}}
 
+    - name: Build in-repo dependencies into local repo
+      # Build this module's in-repo upstream dependencies (e.g. processpuzzle-core)
+      # from source into ~/.m2 so the deploy below resolves them locally instead of
+      # from Maven Central. A freshly-released sibling published via the Central
+      # Portal has not necessarily propagated to repo.maven.apache.org yet, which
+      # otherwise breaks a downstream release (processpuzzle-store 1.1.0 could not
+      # find processpuzzle-core 1.1.0). -am pulls in only upstream deps and is a
+      # no-op for libs with no in-repo dependencies (e.g. api-contracts).
+      run: mvn --batch-mode -pl ${{ inputs.base_dir }} -am -DskipTests -Dgpg.skip install
+      working-directory: ${{ github.workspace }}
+      shell: bash
+
     - name: Publish to Maven Central
       run: mvn --batch-mode --settings ${{ github.workspace }}/settings.xml deploy -Prelease
       working-directory: ${{ inputs.base_dir }}


### PR DESCRIPTION
The single-module `mvn deploy` resolved sibling artifacts (e.g. processpuzzle-core) from Maven Central. A freshly-released sibling published via the Central Portal has not necessarily propagated to repo.maven.apache.org yet, so a downstream release fails with "Could not find artifact ...core:jar:<version> in central" (processpuzzle-store 1.1.0 needing processpuzzle-core 1.1.0).

Add a root-reactor `mvn -pl <base_dir> -am -DskipTests -Dgpg.skip install` before the deploy so upstream in-repo dependencies are built from source into ~/.m2 and resolved locally. -am is a no-op for libs with no in-repo dependencies (e.g. api-contracts).