### PR TITLE
release(auth): 0.8.2

### DIFF
--- a/libs/js-shared/auth/package.json
+++ b/libs/js-shared/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processpuzzle/auth",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release **auth** at **0.8.2** (patch bump).

The npm publish workflow triggers on push to `release/auth/0.8.2`. Merge this PR after publish succeeds.