### PR TITLE
release(base-entity-frontend): 1.1.0

### DIFF
--- a/libs/js-shared/base-entity-frontend/package.json
+++ b/libs/js-shared/base-entity-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processpuzzle/base-entity",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "MIT",
   "author": {
     "name": "Zsolt Zsuffa",


### PR DESCRIPTION
Release **base-entity-frontend** at **1.1.0** (minor bump).

The npm publish workflow triggers on push to `release/base-entity-frontend/1.1.0`. Merge this PR after publish succeeds.