### PR TITLE
release(auth): 0.8.3

### DIFF
--- a/libs/js-shared/auth/domain/service/keycloak-auth.service.spec.ts
+++ b/libs/js-shared/auth/domain/service/keycloak-auth.service.spec.ts
@@ -79,7 +79,7 @@ describe('KeycloakAuthService', () => {
       mockKeycloakInstance.authenticated = false;
       await service.login('dashboard');
       expect(mockKeycloakInstance.login).toHaveBeenCalledWith({
-        redirectUri: (globalThis.location as any).origin + '/dashboard',
+        redirectUri: new URL('dashboard', document.baseURI).href,
       });
     });
 
@@ -107,7 +107,7 @@ describe('KeycloakAuthService', () => {
     it('should call keycloak.logout and clear user signal', async () => {
       await service.logout('home');
       expect(mockKeycloakInstance.logout).toHaveBeenCalledWith({
-        redirectUri: (globalThis.location as any).origin + '/home',
+        redirectUri: new URL('home', document.baseURI).href,
       });
       expect(service.getCurrentUser()).toBeUndefined();
     });

--- a/libs/js-shared/auth/package.json
+++ b/libs/js-shared/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processpuzzle/auth",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release **auth** at **0.8.3** (patch bump).

The npm publish workflow triggers on push to `release/auth/0.8.3`. Merge this PR after publish succeeds.