### PR TITLE
release(auth): 0.8.5

### DIFF
--- a/libs/js-shared/auth/package.json
+++ b/libs/js-shared/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processpuzzle/auth",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release **auth** at **0.8.5** (patch bump).

The npm publish workflow triggers on push to `release/auth/0.8.5`. Merge this PR after publish succeeds.