### PR TITLE
release(widgets): 0.9.0

### DIFF
--- a/libs/js-shared/widgets/package.json
+++ b/libs/js-shared/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processpuzzle/widgets",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release **widgets** at **0.9.0** (minor bump).

The npm publish workflow triggers on push to `release/widgets/0.9.0`. Merge this PR after publish succeeds.