### PR TITLE
release(base-rule-backend): 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
              flag) on release; flatten-maven-plugin resolves the reference at publish time. -->
         <api-contracts.version>1.1.0</api-contracts.version>
         <base-app-backend.version>1.1.0</base-app-backend.version>
-        <base-rule-backend.version>1.0.3</base-rule-backend.version>
+        <base-rule-backend.version>1.1.0</base-rule-backend.version>
         <base-state-backend.version>1.0.5</base-state-backend.version>
         <base-workflow-backend.version>1.0.5</base-workflow-backend.version>
         <processpuzzle-core.version>1.1.0</processpuzzle-core.version>


### PR DESCRIPTION
Release **base-rule-backend** at **1.1.0** (minor bump).

The Maven Central deploy workflow triggers on push to `release/base-rule-backend/1.1.0`. On publish success the release-merge composite auto-merges this PR into develop and opens+merges a PR into master.